### PR TITLE
Fix map algebra example

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ __Raster calculation (map algebra)__
 
 Average two rasters:
 
-	gdal_calc.py -A input1.tif -B input2.tif --outfile=output.tif --calc="(A+B)/2"
+	gdal_calc.py -A input1.tif -B input2.tif --outfile=output.tif --calc="(A/2+B/2)"
 
 Add two rasters:
 


### PR DESCRIPTION
The previous example was borrowed from the GDAL documentation, but does not produce the expected output. The amended version produces a raster that averages the values of two rasters.